### PR TITLE
Fix selenium session not created error

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,11 +33,10 @@ jobs:
           distribution: 'temurin'
 
       - name: Build with Maven
-        run: mvn clean install
+        run: mvn -DskipTests clean install
 
-      - name: Run Tests (allow failure)
-        run: mvn test -Dheadless=true || true
-        continue-on-error: true
+      - name: Run Tests (headless)
+        run: mvn test -Dheadless=true
 
       - name: Generate Allure Report via Maven
         run: mvn allure:report

--- a/src/test/java/Basepack/DriverManager.java
+++ b/src/test/java/Basepack/DriverManager.java
@@ -36,7 +36,12 @@ public class DriverManager {
             switch (browser.toLowerCase()) {
                 case "chrome":
                     ChromeOptions chromeOptions = new ChromeOptions();
-                    if (headless) chromeOptions.addArguments("--headless=new");
+                    if (headless) {
+                        chromeOptions.addArguments("--headless=new");
+                        chromeOptions.addArguments("--no-sandbox");
+                        chromeOptions.addArguments("--disable-dev-shm-usage");
+                        chromeOptions.addArguments("--disable-gpu");
+                    }
                     chromeOptions.setExperimentalOption("prefs", buildPrefs());
                     capabilities.merge(chromeOptions);
                     capabilities.setBrowserName("chrome");
@@ -120,8 +125,14 @@ public class DriverManager {
     }
 
     public static void closeDriver() {
-        driver.get().quit();
-
+        WebDriver currentDriver = driver.get();
+        if (currentDriver != null) {
+            try {
+                currentDriver.quit();
+            } finally {
+                driver.remove();
+            }
+        }
     }
 }
 

--- a/src/test/java/stepDefinitions/Hooks.java
+++ b/src/test/java/stepDefinitions/Hooks.java
@@ -47,7 +47,7 @@ public class Hooks {
             logger.info("Scenario passed: " + scenario.getName());
             Allure.addAttachment("Test passed", "Executed successfully");
         }
-        //DriverManager.closeDriver();
+        DriverManager.closeDriver();
     }
 
 


### PR DESCRIPTION
Add CI-safe Chrome options, ensure driver teardown, and streamline GitHub Actions to fix `SessionNotCreatedException` in CI.

The `SessionNotCreatedException` with "user data directory is already in use" typically occurs in CI environments when Chrome profiles are not properly managed, leading to locks or conflicts. These changes ensure that each browser instance is properly closed and its resources released, and configure Chrome with options suitable for headless CI execution, preventing profile-related issues and improving overall stability.

---
<a href="https://cursor.com/background-agent?bcId=bc-0efe9eda-5f61-486a-93d2-eb41ace161f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0efe9eda-5f61-486a-93d2-eb41ace161f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

